### PR TITLE
Todoタイトル編集用の PUT エンドポイントを追加

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,10 @@ class TodoCreate(BaseModel):
     title: str
 
 
+class TodoUpdate(BaseModel):
+    title: str
+
+
 class TodoResponse(BaseModel):
     id: int
     title: str
@@ -43,6 +47,17 @@ def create_todo(body: TodoCreate):
     next_id += 1
     todos.append(todo)
     return todo
+
+
+@app.put("/todos/{todo_id}", response_model=TodoResponse)
+def update_todo(todo_id: int, body: TodoUpdate):
+    if not body.title.strip():
+        raise HTTPException(status_code=422, detail="Title must not be empty")
+    for todo in todos:
+        if todo["id"] == todo_id:
+            todo["title"] = body.title
+            return todo
+    raise HTTPException(status_code=404, detail="Todo not found")
 
 
 @app.patch("/todos/{todo_id}", response_model=TodoResponse)


### PR DESCRIPTION
## Summary
- `PUT /todos/{todo_id}` エンドポイントを追加し、Todoのタイトル編集を可能に
- 空文字タイトルに対する422バリデーション、存在しないIDに対する404エラーを実装

Closes #2

## Test plan
- [ ] `PUT /todos/{todo_id}` に有効なタイトルを送信して更新されることを確認
- [ ] 空文字タイトルで422エラーが返ることを確認
- [ ] 存在しないIDで404エラーが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)